### PR TITLE
Fix name bug

### DIFF
--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -1019,7 +1019,7 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
      */
     private void checkVoltageLevel(VoltageLevel v, Boolean checked) {
         selectableVoltageLevels.stream()
-                .filter(selectableVoltageLevel -> selectableVoltageLevel.getIdOrName().equals(showNames.isSelected() ? v.getName() : v.getId()))
+                .filter(selectableVoltageLevel -> selectableVoltageLevel.getId().equals(v.getId()))
                 .forEach(selectableVoltageLevel -> selectableVoltageLevel.setCheckedProperty(checked));
     }
 
@@ -1028,7 +1028,7 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
      */
     private void checkSubstation(Substation s, Boolean checked) {
         selectableSubstations.stream()
-                .filter(selectableSubstation -> selectableSubstation.getIdOrName().equals(showNames.isSelected() ? s.getName() : s.getId()))
+                .filter(selectableSubstation -> selectableSubstation.getId().equals(s.getId()))
                 .forEach(selectableSubstation -> selectableSubstation.setCheckedProperty(checked));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No

**What kind of change does this PR introduce?** 
Bug fix


**What is the current behavior?**
When show names is checked and several voltage levels / substations have the same name, then if one of those is selected, all others are also selected. As many substations have `"undefined"` as name in some files, selecting such a substation freezes the viewer


**What is the new behavior (if this is a feature change)?**
The susbtations / voltage levels added in the checked tab are based on their id, even if show names is checked.


**Does this PR introduce a breaking change or deprecate an API?**
No