### PR TITLE
Adapt to substation layout corrections

### DIFF
--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -833,7 +833,7 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
 
     private String getString(Container<?> value) {
         String cNameOrId = showNames.isSelected() ? value.getNameOrId() : value.getId();
-        if (value instanceof Substation) {
+        if (value instanceof Substation && hideVoltageLevels.isSelected()) {
             long nbVoltageLevels = ((Substation) value).getVoltageLevelStream().count();
             return cNameOrId + " [" + nbVoltageLevels + "]";
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Update following powsybl/powsybl-single-line-diagram#263



**What is the current behavior?**
Not supporting refactor changes of powsybl/powsybl-single-line-diagram#263. Snakelines are redrawn by calling old static methods of ForceSubstationLayout when moving voltage level, incorrectly though: the 2wt/3wt middle node is not moved and is considered as a feeder node.


**What is the new behavior (if this is a feature change)?**
Supporting refactor changes by removing snakelines redrawing. Issue created: #14 




**Does this PR introduce a breaking change or deprecate an API?** 
No

