### PR TITLE
Voltage level first buses aligned

### DIFF
--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -576,7 +576,6 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         cb.getItems().setAll(initializer);
         cb.getSelectionModel().select(initializer[0]);
         cb.setConverter(converter);
-        cb.setEditable(true);
         cb.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> setParameters(updater.apply(layoutParameters.get(), newValue)));
         cb.valueProperty().addListener((observable, oldValue, newValue) -> setParameters(updater.apply(layoutParameters.get(), newValue)));
         parametersPane.add(new Label(label), 0, row);

--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -567,6 +567,22 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         parametersPane.add(cb, 0, row);
     }
 
+    private <E> void addComboBox(String label, int row,
+                                 E[] initializer,
+                                 StringConverter<E> converter,
+                                 BiFunction<LayoutParameters, E, LayoutParameters> updater) {
+
+        ComboBox<E> cb = new ComboBox<>();
+        cb.getItems().setAll(initializer);
+        cb.getSelectionModel().select(initializer[0]);
+        cb.setConverter(converter);
+        cb.setEditable(true);
+        cb.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> setParameters(updater.apply(layoutParameters.get(), newValue)));
+        cb.valueProperty().addListener((observable, oldValue, newValue) -> setParameters(updater.apply(layoutParameters.get(), newValue)));
+        parametersPane.add(new Label(label), 0, row);
+        parametersPane.add(cb, 0, row + 1);
+    }
+
     private void initPositionLayoutCheckBox(Predicate<PositionVoltageLevelLayoutFactory> initializer, CheckBox stackCb) {
         VoltageLevelLayoutFactory layoutFactory = getVoltageLevelLayoutFactory();
         stackCb.setSelected(layoutFactory instanceof PositionVoltageLevelLayoutFactory && initializer.test((PositionVoltageLevelLayoutFactory) layoutFactory));
@@ -722,6 +738,19 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         addSpinner("Min space between components:", 8, 60, 1, rowIndex, LayoutParameters::getMinSpaceBetweenComponents, LayoutParameters::setMinSpaceBetweenComponents);
         rowIndex += 2;
         addSpinner("Minimum extern cell height:", 80, 300, 10, rowIndex, LayoutParameters::getMinExternCellHeight, LayoutParameters::setMinExternCellHeight);
+
+        rowIndex += 2;
+        StringConverter<LayoutParameters.Alignment> converter = new StringConverter<>() {
+            @Override
+            public String toString(LayoutParameters.Alignment object) {
+                 return object.name();
+            }
+            @Override
+            public LayoutParameters.Alignment fromString(String string) {
+                return LayoutParameters.Alignment.valueOf(string);
+            }
+        };
+        addComboBox("BusBar alignment:", rowIndex, LayoutParameters.Alignment.values(), converter, LayoutParameters::setBusbarsAlignment);
 
         rowIndex += 2;
         addCheckBox("Center label:", rowIndex, LayoutParameters::isLabelCentered, LayoutParameters::setLabelCentered);


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#281


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
First bus of each voltage level are not aligned if LayoutParameters.isAdaptCellHeightToContent()


**What is the new behavior (if this is a feature change)?**
The first busbars of each voltage level are aligned. A parameter in LayoutParameters is added to give the align value.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
