### PR TITLE
Bug fix if last opened directory deleted

### DIFF
--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -1046,19 +1046,17 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
             FileChooser fileChooser = new FileChooser();
             fileChooser.setTitle("Open case File");
 
-            File file;
-
-            try {
-                String caseFolderPropertyValue = preferences.get(CASE_FOLDER_PROPERTY, null);
-                if (caseFolderPropertyValue != null) {
-                    fileChooser.setInitialDirectory(new File(caseFolderPropertyValue));
-                }
-                file = fileChooser.showOpenDialog(primaryStage);
+            String caseFolderPropertyValue = preferences.get(CASE_FOLDER_PROPERTY, null);
+            if (caseFolderPropertyValue != null) {
+                fileChooser.setInitialDirectory(new File(caseFolderPropertyValue));
             }
 
-            catch (IllegalArgumentException e) {
-                fileChooser = new FileChooser();
-                fileChooser.setTitle("Open case File");
+            File file;
+            try {
+                file = fileChooser.showOpenDialog(primaryStage);
+            } catch (IllegalArgumentException e) {
+                LOGGER.info("Could not set initial directory to last used file directory");
+                fileChooser.setInitialDirectory(null);
                 file = fileChooser.showOpenDialog(primaryStage);
             }
 

--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -1022,9 +1022,6 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         networkService.setOnFailed(event -> {
             Throwable exception = event.getSource().getException();
             LOGGER.error(exception.toString(), exception);
-            if (exception instanceof com.powsybl.commons.PowsyblException) {
-                LOGGER.info("The last loaded file is likely to have been deleted from the computer. You may proceed.");
-            }
             casePathTextField.setText("");
             caseLoadingStatus.setStyle("-fx-background-color: red");
         });

--- a/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
+++ b/single-line-diagram-viewer/src/main/java/com/powsybl/sld/viewer/SingleLineDiagramViewer.java
@@ -1022,6 +1022,9 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         networkService.setOnFailed(event -> {
             Throwable exception = event.getSource().getException();
             LOGGER.error(exception.toString(), exception);
+            if (exception instanceof com.powsybl.commons.PowsyblException) {
+                LOGGER.info("The last loaded file is likely to have been deleted from the computer. You may proceed.");
+            }
             casePathTextField.setText("");
             caseLoadingStatus.setStyle("-fx-background-color: red");
         });
@@ -1044,12 +1047,24 @@ public class SingleLineDiagramViewer extends Application implements DisplayVolta
         Button caseButton = new Button("...");
         caseButton.setOnAction(event -> {
             FileChooser fileChooser = new FileChooser();
-            String caseFolderPropertyValue = preferences.get(CASE_FOLDER_PROPERTY, null);
-            if (caseFolderPropertyValue != null) {
-                fileChooser.setInitialDirectory(new File(caseFolderPropertyValue));
-            }
             fileChooser.setTitle("Open case File");
-            File file = fileChooser.showOpenDialog(primaryStage);
+
+            File file;
+
+            try {
+                String caseFolderPropertyValue = preferences.get(CASE_FOLDER_PROPERTY, null);
+                if (caseFolderPropertyValue != null) {
+                    fileChooser.setInitialDirectory(new File(caseFolderPropertyValue));
+                }
+                file = fileChooser.showOpenDialog(primaryStage);
+            }
+
+            catch (IllegalArgumentException e) {
+                fileChooser = new FileChooser();
+                fileChooser.setTitle("Open case File");
+                file = fileChooser.showOpenDialog(primaryStage);
+            }
+
             if (file != null) {
                 loadNetwork(file.toPath());
             }


### PR DESCRIPTION
Fix errors when last opened directory has been deleted in between uses of the sld-viewer.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** No



**What kind of change does this PR introduce?** Bug fix



**What is the current behavior?** If last opened directory is deleted, the viewer cannot be launched anymore without re-cloning the whole project or flushing the system variables.



**What is the new behavior (if this is a feature change)?** No bug anymore.



**Does this PR introduce a breaking change or deprecate an API?** No
