### PR TITLE
add new checkbox on viewer to display line names or not

### DIFF
--- a/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/MainViewController.java
+++ b/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/MainViewController.java
@@ -80,6 +80,8 @@ public class MainViewController implements ChangeListener<Object> {
     @FXML
     public CheckBox infoAlongEdge;
     @FXML
+    public CheckBox lineNameDisplayed;
+    @FXML
     public CheckBox insertNameDesc;
     @FXML
     public CheckBox substationDescriptionDisplayed;
@@ -127,6 +129,7 @@ public class MainViewController implements ChangeListener<Object> {
 
                 idDisplayed.selectedProperty(),
                 infoAlongEdge.selectedProperty(),
+                lineNameDisplayed.selectedProperty(),
                 insertNameDesc.selectedProperty(),
                 substationDescriptionDisplayed.selectedProperty(),
                 busLegend.selectedProperty(),
@@ -150,6 +153,7 @@ public class MainViewController implements ChangeListener<Object> {
 
         idDisplayed.selectedProperty().addListener(this);
         infoAlongEdge.selectedProperty().addListener(this);
+        lineNameDisplayed.selectedProperty().addListener(this);
         insertNameDesc.selectedProperty().addListener(this);
         substationDescriptionDisplayed.selectedProperty().addListener(this);
         busLegend.selectedProperty().addListener(this);

--- a/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/MainViewController.java
+++ b/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/MainViewController.java
@@ -80,7 +80,7 @@ public class MainViewController implements ChangeListener<Object> {
     @FXML
     public CheckBox infoAlongEdge;
     @FXML
-    public CheckBox lineNameDisplayed;
+    public CheckBox edgeNameDisplayed;
     @FXML
     public CheckBox insertNameDesc;
     @FXML
@@ -129,7 +129,7 @@ public class MainViewController implements ChangeListener<Object> {
 
                 idDisplayed.selectedProperty(),
                 infoAlongEdge.selectedProperty(),
-                lineNameDisplayed.selectedProperty(),
+                edgeNameDisplayed.selectedProperty(),
                 insertNameDesc.selectedProperty(),
                 substationDescriptionDisplayed.selectedProperty(),
                 busLegend.selectedProperty(),
@@ -153,7 +153,7 @@ public class MainViewController implements ChangeListener<Object> {
 
         idDisplayed.selectedProperty().addListener(this);
         infoAlongEdge.selectedProperty().addListener(this);
-        lineNameDisplayed.selectedProperty().addListener(this);
+        edgeNameDisplayed.selectedProperty().addListener(this);
         insertNameDesc.selectedProperty().addListener(this);
         substationDescriptionDisplayed.selectedProperty().addListener(this);
         busLegend.selectedProperty().addListener(this);

--- a/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/Model.java
+++ b/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/Model.java
@@ -42,6 +42,7 @@ public class Model {
     // SVG Parameters
     private final BooleanProperty idDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty infoAlongEdge = new SimpleBooleanProperty();
+    private final BooleanProperty lineNameDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty insertNameDesc = new SimpleBooleanProperty();
     private final BooleanProperty substationDescriptionDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty busLegend = new SimpleBooleanProperty();
@@ -72,6 +73,7 @@ public class Model {
                  // SVG parameters
                  BooleanProperty idDisplayed,
                  BooleanProperty infoAlongEdge,
+                 BooleanProperty lineNameDisplayed,
                  BooleanProperty insertNameDesc,
                  BooleanProperty substationDescriptionDisplayed,
                  BooleanProperty busLegend,
@@ -93,6 +95,7 @@ public class Model {
         // SVG parameters
         this.idDisplayed.bind(idDisplayed);
         this.infoAlongEdge.bind(infoAlongEdge);
+        this.lineNameDisplayed.bind(lineNameDisplayed);
         this.insertNameDesc.bind(insertNameDesc);
         this.substationDescriptionDisplayed.bind(substationDescriptionDisplayed);
         this.busLegend.bind(busLegend);
@@ -139,6 +142,7 @@ public class Model {
                 .setBusLegend(busLegend.get())
                 .setVoltageLevelDetails(vlDetails.get())
                 .setEdgeInfoAlongEdge(infoAlongEdge.get())
+                .setLineNameDisplayed(lineNameDisplayed.get())
                 .setSvgWidthAndHeightAdded(widthHeightAdded.get())
                 .setSizeConstraint(sizeConstraint.get());
         switch (sizeConstraint.get()) {

--- a/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/Model.java
+++ b/network-area-diagram-viewer/src/main/java/com/powsybl/nad/viewer/Model.java
@@ -42,7 +42,7 @@ public class Model {
     // SVG Parameters
     private final BooleanProperty idDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty infoAlongEdge = new SimpleBooleanProperty();
-    private final BooleanProperty lineNameDisplayed = new SimpleBooleanProperty();
+    private final BooleanProperty edgeNameDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty insertNameDesc = new SimpleBooleanProperty();
     private final BooleanProperty substationDescriptionDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty busLegend = new SimpleBooleanProperty();
@@ -73,7 +73,7 @@ public class Model {
                  // SVG parameters
                  BooleanProperty idDisplayed,
                  BooleanProperty infoAlongEdge,
-                 BooleanProperty lineNameDisplayed,
+                 BooleanProperty edgeNameDisplayed,
                  BooleanProperty insertNameDesc,
                  BooleanProperty substationDescriptionDisplayed,
                  BooleanProperty busLegend,
@@ -95,7 +95,7 @@ public class Model {
         // SVG parameters
         this.idDisplayed.bind(idDisplayed);
         this.infoAlongEdge.bind(infoAlongEdge);
-        this.lineNameDisplayed.bind(lineNameDisplayed);
+        this.edgeNameDisplayed.bind(edgeNameDisplayed);
         this.insertNameDesc.bind(insertNameDesc);
         this.substationDescriptionDisplayed.bind(substationDescriptionDisplayed);
         this.busLegend.bind(busLegend);
@@ -142,7 +142,7 @@ public class Model {
                 .setBusLegend(busLegend.get())
                 .setVoltageLevelDetails(vlDetails.get())
                 .setEdgeInfoAlongEdge(infoAlongEdge.get())
-                .setLineNameDisplayed(lineNameDisplayed.get())
+                .setEdgeNameDisplayed(edgeNameDisplayed.get())
                 .setSvgWidthAndHeightAdded(widthHeightAdded.get())
                 .setSizeConstraint(sizeConstraint.get());
         switch (sizeConstraint.get()) {

--- a/network-area-diagram-viewer/src/main/resources/mainView.fxml
+++ b/network-area-diagram-viewer/src/main/resources/mainView.fxml
@@ -114,6 +114,7 @@
                     </Separator>
                     <GridPane hgap="5" vgap="5">
                         <Label style="-fx-font-weight: bold" text="SVG parameters:" GridPane.rowIndex="0"/>
+                        <CheckBox fx:id="lineNameDisplayed" text="Display line name" selected="true" GridPane.rowIndex="1"/>
                         <CheckBox fx:id="infoAlongEdge" text="Set Info Along Edge" selected="true" GridPane.rowIndex="2"/>
                         <CheckBox fx:id="idDisplayed" text="Display id (instead of name)" selected="false" GridPane.rowIndex="3"/>
                         <CheckBox fx:id="insertNameDesc" text="Insert desc elements" selected="true" GridPane.rowIndex="4"/>

--- a/network-area-diagram-viewer/src/main/resources/mainView.fxml
+++ b/network-area-diagram-viewer/src/main/resources/mainView.fxml
@@ -114,7 +114,7 @@
                     </Separator>
                     <GridPane hgap="5" vgap="5">
                         <Label style="-fx-font-weight: bold" text="SVG parameters:" GridPane.rowIndex="0"/>
-                        <CheckBox fx:id="lineNameDisplayed" text="Display line name" selected="true" GridPane.rowIndex="1"/>
+                        <CheckBox fx:id="edgeNameDisplayed" text="Display edge name" selected="true" GridPane.rowIndex="1"/>
                         <CheckBox fx:id="infoAlongEdge" text="Set Info Along Edge" selected="true" GridPane.rowIndex="2"/>
                         <CheckBox fx:id="idDisplayed" text="Display id (instead of name)" selected="false" GridPane.rowIndex="3"/>
                         <CheckBox fx:id="insertNameDesc" text="Insert desc elements" selected="true" GridPane.rowIndex="4"/>


### PR DESCRIPTION
Signed-off-by: Sophie Frasnedo <sophie.frasnedo@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New tick box to allow the user to display line names or not


**What is the current behavior?** *(You can also link to an open issue here)*
No line names displayed, no tick box present



**What is the new behavior (if this is a feature change)?**
Tick box added
![lineNameTickbox](https://user-images.githubusercontent.com/93923177/210594796-f9e593a6-5554-4bfb-a56e-dab22d2c761f.jpg)
