### PR TITLE
NAD : rotate boundary node according to new dangling line orientation

### DIFF
--- a/network-area-diagram-viewer/src/main/resources/svg.js
+++ b/network-area-diagram-viewer/src/main/resources/svg.js
@@ -118,7 +118,7 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
         // the element that is being moved has to have an id
         var id = svgElem.getAttribute("id");
         if (id) {
-        updateOnClient(id, svgElem, translation);
+            updateOnClient(id, svgElem, translation);
         } else {
             console.log("error trying to update: moved element has no id attribute");
         }
@@ -192,6 +192,10 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
         var nonStretchables = findNonStretchables(edgeSvg);
         var s = (d1 - nonStretchables.d) / (d0 - nonStretchables.d);
 
+        if (isDanglingLine(edgeSvg)) {
+            // Rotate the boundary node according to new edge orientation
+            updateBoundaryNode((movedNodeSide === 2 ? movedNodeId : otherNodeId), a0, a1);
+        }
         updateEdgeTransform(edgeSvg, edgeId, movedNodeSide, p0, q0, p1, q1, a0, a1, s, nonStretchables);
     }
 
@@ -214,6 +218,17 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
                 updateEdgePartTransform(part, edgeTransforms[edgeId][part.id], movedNodeSide, p0, q0, p1, q1, a0, a1, s, nonStretchables);
             }
         }
+    }
+
+    var boundaryNodeTransforms = {};
+    function updateBoundaryNode(nodeId, a0, a1) {
+        var nodeSvg = svg.getElementById(nodeId);
+        if (!(nodeId in boundaryNodeTransforms)) {
+            var transform = svg.createSVGTransform();
+            nodeSvg.transform.baseVal.appendItem(transform);
+            boundaryNodeTransforms[nodeId] = transform;
+        }
+        boundaryNodeTransforms[nodeId].setRotate(a1 - a0, 0, 0);
     }
 
     function createCachedTransform(edgeId, part) {
@@ -273,6 +288,10 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
             .translate(-nonStretchables.dside, 0)
             .rotate(-a0)
             .translate(-referencePoint0.x, -referencePoint0.y));
+    }
+
+    function isDanglingLine(svgElem) {
+        return svgElem.classList.contains("nad-dangling-line-edge");
     }
 
     function getGluedToSide(svgElem) {


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Boundary nodes are drawn as semi-circles. When they are moved the related dangling line changes its orientation, and the semi-circle is not drawn properly.

<img width="218" alt="boundary-not-rotated" src="https://user-images.githubusercontent.com/3374819/211350727-c6f4d8b3-5380-4cd3-a53b-ca351b4bdea7.png">

**What is the new behavior (if this is a feature change)?**
When boundary nodes are moved, its drawing is rotated following the new orientation of the related dangling line.

<img width="222" alt="boundary-rotated" src="https://user-images.githubusercontent.com/3374819/211350790-1a36f6fb-4169-42d8-ad48-a85bd4e9a918.png">

