### PR TITLE
[nad-viewer] Replace element center calculation with getting translation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           repository: powsybl/powsybl-diagram
-          ref: refs/heads/translate_circle
+          ref: refs/heads/main
 
       - name: Checkout sources
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           repository: powsybl/powsybl-diagram
-          ref: refs/heads/main
+          ref: refs/heads/translate_circle
 
       - name: Checkout sources
         uses: actions/checkout@v2.3.4

--- a/network-area-diagram-viewer/src/main/resources/svg.js
+++ b/network-area-diagram-viewer/src/main/resources/svg.js
@@ -176,8 +176,8 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
         var p0 = {x: parseFloat(movedNodeMetadata.getAttribute("x")), y: parseFloat(movedNodeMetadata.getAttribute("y"))};
         var q0 = {x: parseFloat(otherNodeMetadata.getAttribute("x")), y: parseFloat(otherNodeMetadata.getAttribute("y"))};
         var a0 = calcRotation(p0, q0);
-        var p1 = center(movedNodeSvg);
-        var q1 = center(otherNodeSvg);
+        var p1 = currentTranslation(movedNodeSvg);
+        var q1 = currentTranslation(otherNodeSvg);
         var a1 = calcRotation(p1, q1);
 
         if (!(edgeId in cachedEdgeDistances0)) {
@@ -317,14 +317,9 @@ function Diagram(svg, svgTools, nonStretchableSideSize, nonStretchableCenterSize
         return element.classList.contains("nad-stretchable");
     }
 
-    function center(svgElem) {
-        var rect = svgElem.getBoundingClientRect();
-        var center = {x: rect.x + .5 * rect.width, y: rect.y + .5 * rect.height};
-        var CTM = svg.getScreenCTM();
-        if (CTM) {
-            center.x = (center.x - CTM.e) / CTM.a;
-            center.y = (center.y - CTM.f) / CTM.d;
-        }
+    function currentTranslation(svgElem) {
+        var transform = svgTools.getTransformsEnsuringFirstIsTranslation(svgElem).getItem(0);
+        var center = {x: transform.matrix.e, y: transform.matrix.f};
         return center;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
The position of an element is guessed by calculating its bounding box center, which is quite risky



**What is the new behavior (if this is a feature change)?**
The position of an element is read in the element translation


**Does this PR introduce a breaking change or deprecate an API?**
No

**Other information**:
3wt nodes should be translated and not with cx/cy in the circles containing the translation