### PR TITLE
Clean diagram when error occurs in SingleLineDiagram::draw

### DIFF
--- a/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/sld/SingleLineDiagramController.java
+++ b/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/sld/SingleLineDiagramController.java
@@ -9,12 +9,14 @@ package com.powsybl.diagram.viewer.sld;
 
 import com.powsybl.diagram.viewer.common.AbstractDiagramController;
 import com.powsybl.diagram.viewer.common.ContainerResult;
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Container;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Switch;
 import com.powsybl.sld.SingleLineDiagram;
 import com.powsybl.sld.SldParameters;
-import com.powsybl.sld.layout.*;
+import com.powsybl.sld.layout.VoltageLevelLayoutFactoryCreator;
 import com.powsybl.sld.svg.styles.StyleProvider;
-import javafx.beans.property.*;
+import javafx.beans.property.StringProperty;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
@@ -23,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.io.UncheckedIOException;
 
 /**
  * @author Thomas Adam <tadam at slicom.fr>
@@ -86,7 +87,7 @@ public class SingleLineDiagramController extends AbstractDiagramController {
             protected Task<ContainerResult> createTask() {
                 return new Task<>() {
                     @Override
-                    protected ContainerResult call() {
+                    protected ContainerResult call() throws IOException {
                         ContainerResult result = new ContainerResult();
                         try (StringWriter svgWriter = new StringWriter();
                              StringWriter metadataWriter = new StringWriter();
@@ -110,8 +111,6 @@ public class SingleLineDiagramController extends AbstractDiagramController {
                             result.svgContentProperty().set(svgWriter.toString());
                             result.metadataContentProperty().set(metadataWriter.toString());
                             result.jsonContentProperty().set(jsonWriter.toString());
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
                         }
                         return result;
                     }
@@ -122,7 +121,8 @@ public class SingleLineDiagramController extends AbstractDiagramController {
         sldService.setOnSucceeded(event -> containerResult.setValue((ContainerResult) event.getSource().getValue()));
         sldService.setOnFailed(event -> {
             Throwable exception = event.getSource().getException();
-            LOGGER.error(exception.toString(), exception);
+            containerResult.clean();
+            LOGGER.error("Error while drawing single-line diagram {}", container.getId(), exception);
         });
         sldService.start();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
When error occurs in SingleLineDiagram::draw, previous diagram displayed is not cleared



**What is the new behavior (if this is a feature change)?**
When error occurs, previous diagram displayed is cleared
