### PR TITLE
Diagram viewer : check that recorded case folder still exists

### DIFF
--- a/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/MainViewController.java
+++ b/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/MainViewController.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -263,7 +265,7 @@ public class MainViewController {
     private File selectFile() {
         FileChooser fileChooser = new FileChooser();
         String caseFolderPropertyValue = preferences.get(CASE_FOLDER_PROPERTY, null);
-        if (caseFolderPropertyValue != null) {
+        if (caseFolderPropertyValue != null && Files.isDirectory(Path.of(caseFolderPropertyValue))) {
             fileChooser.setInitialDirectory(new File(caseFolderPropertyValue));
         }
         fileChooser.setTitle("Open case File");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If the case folder previously recorded in preferences is removed from the file system the open case dialog is not shown.


**What is the new behavior (if this is a feature change)?**
only set the start folder for open case dialog from the value recorded in preferences if it still an existing directory


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
