### PR TITLE
Full network not selectable in NAD

### DIFF
--- a/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/nad/NetworkAreaDiagramController.java
+++ b/diagram-viewer/src/main/java/com/powsybl/diagram/viewer/nad/NetworkAreaDiagramController.java
@@ -79,7 +79,7 @@ public class NetworkAreaDiagramController extends AbstractDiagramController {
 
     private static Predicate<VoltageLevel> getVoltageLevelFilter(Network network, NetworkAreaDiagramModel model, Container<?> container) {
         return switch (container.getContainerType()) {
-            case NETWORK -> VoltageLevelFilter.NO_FILTER;
+            case NETWORK -> null;
             case SUBSTATION -> VoltageLevelFilter.createVoltageLevelsDepthFilter(network, ((Substation) container).getVoltageLevelStream().map(VoltageLevel::getId).toList(), model.getDepth());
             case VOLTAGE_LEVEL -> VoltageLevelFilter.createVoltageLevelDepthFilter(network, container.getId(), model.getDepth());
         };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug bypass

**What is the current behavior?**
the full network gets selected after inactivity, causing the application to freeze/crash

**What is the new behavior (if this is a feature change)?**
no network-area diagram is displayed when the full network gets selected 

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No